### PR TITLE
Use/Follow the Root Directory Configuration Settings

### DIFF
--- a/app/workers/tasks/deploy.py
+++ b/app/workers/tasks/deploy.py
@@ -86,6 +86,14 @@ async def deploy_start(ctx, deployment_id: str):
                 }
                 # env_vars_dict["PIP_DISABLE_PIP_VERSION_CHECK"] = "1"
 
+                # Get configuration values
+                image = deployment.config.get("image")
+                root_directory = deployment.config.get("root_directory") or "/app"
+
+                # Always start in /app where the repository is cloned
+                # Custom root directory is handled via cd command in the script
+                working_dir = "/app"
+
                 # Prepare commands
                 commands = []
 
@@ -168,14 +176,6 @@ async def deploy_start(ctx, deployment_id: str):
                     logger.warning(
                         f"{log_prefix} Invalid CPU/memory values in config, using defaults."
                     )
-
-                image = deployment.config.get("image")
-
-                root_directory = deployment.config.get("root_directory") or "/app"
-
-                # Always start in /app where the repository is cloned
-                # Custom root directory is handled via cd command in the script
-                working_dir = "/app"
 
                 # Create and start container
                 container = await docker_client.containers.create_or_replace(

--- a/app/workers/tasks/deploy.py
+++ b/app/workers/tasks/deploy.py
@@ -161,6 +161,9 @@ async def deploy_start(ctx, deployment_id: str):
 
                 image = deployment.config.get("image")
 
+                root_directory = deployment.config.get("root_directory") or "/app"
+
+
                 # Create and start container
                 container = await docker_client.containers.create_or_replace(
                     name=container_name,
@@ -168,7 +171,7 @@ async def deploy_start(ctx, deployment_id: str):
                         "Image": f"runner-{image}",
                         "Cmd": ["/bin/sh", "-c", " && ".join(commands)],
                         "Env": [f"{k}={v}" for k, v in env_vars_dict.items()],
-                        "WorkingDir": "/app",
+                        "WorkingDir": root_directory,
                         "Labels": labels,
                         "NetworkingConfig": {"EndpointsConfig": {"devpush_runner": {}}},
                         "HostConfig": {


### PR DESCRIPTION
## Summary

This PR fixes a critical issue where the root directory setting in project configurations was being ignored, causing all deployments to run from /app regardless of the specified root directory. This enables proper monorepo support by allowing deployments to run from subdirectories like ./apps/api.

## Description
Previously, when users set a custom root directory (e.g., ./apps/api for a monorepo structure), the deployment system would:
  - Ignore the root directory setting entirely
  - Always run commands from /app (container root)
  - Fail to find project files like requirements.txt in subdirectories
  - Cause "file not found" errors for monorepo applications